### PR TITLE
Fix error in copy constructor

### DIFF
--- a/src/main/java/io/discloader/discloader/core/entity/guild/GuildMember.java
+++ b/src/main/java/io/discloader/discloader/core/entity/guild/GuildMember.java
@@ -103,11 +103,7 @@ public class GuildMember implements IGuildMember {
 		user = member.getUser();
 		guild = member.getGuild();
 		nick = member.getNickname();
-		roleIDs = new String[member.getRoles().size()];
-		int i = 0;
-		for (IRole role : member.getRoles().values()) {
-			roleIDs[i] = role.getID();
-		}
+		roleIDs = member.getRoles().keySet().toArray(new String[] { });
 		joinedAt = Date.from(Instant.now());
 		deaf = member.isDeaf();
 		mute = deaf || member.isMuted();


### PR DESCRIPTION
The array copy appears to have a bug (i is never incremented). Using toArray instead.

roleIDs could probably be changed to a `List` or `Set`. It's Arrayness (real word, I swear) doesn't seem to be important.